### PR TITLE
fix: experience section in mobile site

### DIFF
--- a/src/containers/workExperience/WorkExperience.js
+++ b/src/containers/workExperience/WorkExperience.js
@@ -10,7 +10,7 @@ export default function WorkExperience() {
   if (workExperiences.display) {
     return (
       <div id="experience">
-        <Fade bottom duration={1000} distance="20px">
+        <Fade bottom duration={1000} distance="20px" ssrFadeout>
           <div className="experience-container" id="workExperience">
             <div>
               <h1 className="experience-heading">Experiences</h1>


### PR DESCRIPTION
## Understanding the Fade Issue

The Fade component from react-reveal is designed to create a fade-in animation when an element becomes visible. The problem is likely related to how it interacts with:

Initial State: How Fade handles the element's initial state before the animation begins. It might be setting the element to opacity: 0; or display: none; initially and not properly transitioning out of that state on mobile.
Mobile Layout: There may be some conflict with the way the layout is handled on mobile devices, especially related to flexbox, grid, or positioning.
The way the component is nested: It could be possible that the component is nested in a way that it conflict with the parent or children component.
Fixing the Fade Component Issue

Here are several strategies to try, starting with the most straightforward:

ssrFadeout Prop:

Description: react-reveal has a prop called ssrFadeout. This prop can be used to disable the fade animation during server-side rendering. It can often resolve issues like this.
Action:

Modify the Fade component in WorkExperience.js like this:

```js
<Fade bottom duration={1000} distance="20px" ssrFadeout>
```

## Tested on Chrome WebTools (Mobile Site)

![portfolio-mobile-site-fix-fade](https://github.com/user-attachments/assets/f6addce8-066b-474b-bbec-45b7e5e14818)
